### PR TITLE
adapt time functions and types to 64bit among other small changes

### DIFF
--- a/tmf882x_mode_app.c
+++ b/tmf882x_mode_app.c
@@ -509,7 +509,7 @@ static int32_t check_cmd_status_timeout(struct tmf882x_mode_app *app,
     return check_cmd_status(app, MS_TIME_TO_RETRIES(timeout_ms - wait_ms));
 }
 
-static inline uint32_t timespec_to_usec(struct timespec ts)
+static inline uint32_t timespec_to_usec(struct timespec64 ts)
 {
     return ((ts.tv_sec * 1000000) + ((ts.tv_nsec + 500)/ 1000));
 }
@@ -721,7 +721,7 @@ static int32_t clock_skew_correction(struct tmf882x_mode_app *app,
                                      struct tmf882x_msg_meas_results *results)
 {
     // Assume timespec is defined by platform include files
-    struct timespec current_ts = {0};
+    struct timespec64 current_ts = {0};
     uint32_t usec_epoch = 0;
     uint32_t cr_dist = 0;
     uint32_t i = 0;

--- a/tmf882x_mode_app.h
+++ b/tmf882x_mode_app.h
@@ -225,7 +225,7 @@ struct tmf882x_mode_app {
         uint8_t uid[sizeof(uint32_t)];
 
         // cached timestamp used for clock correction
-        struct timespec timestamp;
+        struct timespec64 timestamp;
 
     } volat_data;
 

--- a/tmf882x_shim_linux_kernel.h
+++ b/tmf882x_shim_linux_kernel.h
@@ -84,9 +84,9 @@ static inline int32_t tof_queue_msg(struct tof_sensor_chip *chip, struct tmf882x
     return tof_frwk_queue_msg(chip, msg);
 }
 
-static inline void tof_get_timespec(struct timespec *ts)
+static inline void tof_get_timespec(struct timespec64 *ts)
 {
-    getnstimeofday(ts);
+    ktime_get_real_ts64(ts);
 }
 
 #endif


### PR DESCRIPTION
Adapted time functions and types to 64bit among other small changes in order to be compatible with newer kernels.

changed:
- struct timespec
- getnstimeofday()
- timespec_sub()

to:
- struct timespec64
- ktime_get_real_ts64()
- timespec64_sub()

also changed parameters on:
- tof_probe()
- tof_remove()
to be in line with newer kernels